### PR TITLE
Fixes flocking position calculation to work as expected by tests.

### DIFF
--- a/docs/artificialintelligence/assignments/flocking/flocking.cpp
+++ b/docs/artificialintelligence/assignments/flocking/flocking.cpp
@@ -181,7 +181,7 @@ int main() {
     for (int i = 0; i < numberOfBoids; i++) // for every boid
     {
       newState[i].velocity += allForces[i] * deltaT;
-      newState[i].position += currentState[i].velocity * deltaT;
+      newState[i].position += newState[i].velocity * deltaT;
       cout << newState[i].position.x << " " << newState[i].position.y << " "
            << newState[i].velocity.x << " " << newState[i].velocity.y << endl;
     }


### PR DESCRIPTION
Before this change, the expected results' positions occur one time-step later than they should, so tests do not pass. (When given a starting velocity of 0, the positions of the boids would always remain in that position after the first time-step, which is not expected by the tests.)