### PR TITLE
Fix CMakeLists.txt in flocking

### DIFF
--- a/docs/artificialintelligence/assignments/flocking/CMakeLists.txt
+++ b/docs/artificialintelligence/assignments/flocking/CMakeLists.txt
@@ -3,5 +3,5 @@ add_executable(ai-flocking flocking.cpp)
 file(GLOB TEST_INPUT_FILES ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.in)
 file(GLOB TEST_OUTPUT_FILES ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.out)
 
-add_custom_test(ai-flocking-test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/flocking "${TEST_INPUT_FILES}" "${TEST_OUTPUT_FILES}")
+add_custom_test(ai-flocking-test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ai-flocking "${TEST_INPUT_FILES}" "${TEST_OUTPUT_FILES}")
 


### PR DESCRIPTION
Fixes target executable name to align with actual executable name.